### PR TITLE
Call the close function when the end signal is emitted

### DIFF
--- a/index.js
+++ b/index.js
@@ -165,9 +165,21 @@ DataSourcer.prototype.addSource = function(name, source) {
 	this.sources[name] = source;
 };
 
-DataSourcer.prototype.close = function() {
+DataSourcer.prototype.close = function(done) {
 	if (this.browser) {
-		this.browser.close();
+		this.browser.close().then(function() {
+			if(done) {
+				done();
+			}
+		}).catch(function() {
+			if(done) {
+				done();
+			}
+		});
+	} else {
+		if(done) {
+			done();
+		}
 	}
 };
 

--- a/index.js
+++ b/index.js
@@ -165,14 +165,9 @@ DataSourcer.prototype.addSource = function(name, source) {
 	this.sources[name] = source;
 };
 
-DataSourcer.prototype.close = function(done) {
-
+DataSourcer.prototype.close = function() {
 	if (this.browser) {
-		this.browser.close().then(function() {
-			done();
-		}).catch(done);
-	} else {
-		_.defer(done);
+		this.browser.close();
 	}
 };
 
@@ -266,6 +261,8 @@ DataSourcer.prototype.processData = function(data, fn) {
 DataSourcer.prototype.getData = function(options) {
 
 	var emitter = this.prepareSafeEventEmitter();
+	this.close = this.close.bind(this);
+	emitter.on('end', this.close);
 
 	_.defer(function() {
 


### PR DESCRIPTION
It seems the close method is never called, thus the browser is never closed.

When you run the tests in `proxy-lists` this is not an issue, because it is run as a separate process which is killed once the tests are finished, thus also closing the browser.

I am not sure if I am missing something.

**Edit**:
Since the tests are failing, I am obviously missing something...

Should the implementing library call the sourcers close function? In this case I think it should be documented...